### PR TITLE
Fix Docstrings 

### DIFF
--- a/numpyro/distributions/censored.py
+++ b/numpyro/distributions/censored.py
@@ -33,9 +33,9 @@ class LeftCensoredDistribution(Distribution):
         This distribution must implement a `cdf` method.
     censored : array-like of {0,1}
         Censoring indicator per observation:
+
         - 0 → value is observed exactly
-        - 1 → observation is left-censored at the reported value
-        (true value occurred *on or before* the reported value)
+        - 1 → observation is left-censored at the reported value (true value occurred *on or before* the reported value)
 
     Notes
     -----
@@ -169,12 +169,13 @@ class RightCensoredDistribution(Distribution):
     - In R's **survival** package notation, this corresponds to
       `Surv(time, event)` with `type = "right"`.
 
-        Example:
-        `Surv(time = c(5, 8, 10), event = c(1, 0, 1))`
-        means:
-          * subject 1 had an event at t=5
-          * subject 2 was censored at t=8
-          * subject 3 had an event at t=10
+      Example:
+      `Surv(time = c(5, 8, 10), event = c(1, 0, 1))`
+      means:
+
+      * subject 1 had an event at t=5
+      * subject 2 was censored at t=8
+      * subject 3 had an event at t=10
 
     Examples
     --------


### PR DESCRIPTION
Fix doctring formats in https://github.com/pyro-ppl/numpyro/pull/2081

I've fixed both documentation formatting issues:

1. **LeftCensoredDistribution** (line 33): Added a blank line before the bullet list and properly indented the continuation text for better RST formatting.

2. **RightCensoredDistribution** (line 38): Fixed the indentation of the "Example:" block to be consistent with the surrounding text (6 spaces instead of 8) and added a blank line before the nested bullet list.

The changes ensure proper reStructuredText formatting for the docstrings, which should resolve the docutils warnings and errors when building the documentation.